### PR TITLE
Fix crashing at shutdown

### DIFF
--- a/src/LoadOGL.cpp
+++ b/src/LoadOGL.cpp
@@ -506,7 +506,6 @@ namespace GL { PFNGLGetProcAddress _glGetProcAddress = NULL; }
         {
             NSString *sym = [[NSString alloc] initWithFormat: @"%s%s",gl_prefix,name];
             proc = dlsym(gl_dyld,[sym UTF8String]);
-            [sym release];
         }
         return proc;
     }

--- a/src/LoadOGLCore.cpp
+++ b/src/LoadOGLCore.cpp
@@ -490,7 +490,6 @@ namespace GLCore { PFNGLGetProcAddress _glGetProcAddress = NULL; }
         {
             NSString *sym = [[NSString alloc] initWithFormat: @"%s%s",gl_prefix,name];
             proc = dlsym(gl_dyld,[sym UTF8String]);
-            [sym release];
         }
         return proc;
     }

--- a/src/LoadOGLCore.h
+++ b/src/LoadOGLCore.h
@@ -146,7 +146,7 @@ ANT_GL_CORE_DECL(void, glGetCompressedTexImage, (GLenum target, GLint level, GLv
 // GL 1.4
 ANT_GL_CORE_DECL(void, glBlendFuncSeparate, (GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha))
 ANT_GL_CORE_DECL(void, glMultiDrawArrays, (GLenum mode, const GLint *first, const GLsizei *count, GLsizei primcount))
-ANT_GL_CORE_DECL(void, glMultiDrawElements, (GLenum mode, const GLsizei *count, GLenum type, const GLvoid* *indices, GLsizei primcount))
+ANT_GL_CORE_DECL(void, glMultiDrawElements, (GLenum mode, const GLsizei *count, GLenum type, const GLvoid* const *indices, GLsizei primcount))
 ANT_GL_CORE_DECL(void, glPointParameterf, (GLenum pname, GLfloat param))
 ANT_GL_CORE_DECL(void, glPointParameterfv, (GLenum pname, const GLfloat *params))
 ANT_GL_CORE_DECL(void, glPointParameteri, (GLenum pname, GLint param))
@@ -211,7 +211,7 @@ ANT_GL_CORE_DECL(void, glGetVertexAttribPointerv, (GLuint index, GLenum pname, G
 ANT_GL_CORE_DECL(GLboolean, glIsProgram, (GLuint program))
 ANT_GL_CORE_DECL(GLboolean, glIsShader, (GLuint shader))
 ANT_GL_CORE_DECL(void, glLinkProgram, (GLuint program))
-ANT_GL_CORE_DECL(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* *string, const GLint *length))
+ANT_GL_CORE_DECL(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* const *string, const GLint *length))
 ANT_GL_CORE_DECL(void, glUseProgram, (GLuint program))
 ANT_GL_CORE_DECL(void, glUniform1f, (GLint location, GLfloat v0))
 ANT_GL_CORE_DECL(void, glUniform2f, (GLint location, GLfloat v0, GLfloat v1))

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -4,8 +4,8 @@ SO_EXT		= .dylib
 AR_EXT		= .a
 
 #---- Release
-CXXCFG   	= -O3
-LFLAGS		= 
+CXXCFG   	= -O3 -arch x86_64 -stdlib=libc++ -mmacosx-version-min=10.10
+LFLAGS		= $(CXXCFG)
 OUT_DIR		= ../lib
 #---- Debug
 #CXXCFG   	= -g -D_DEBUG
@@ -13,13 +13,14 @@ OUT_DIR		= ../lib
 #OUT_DIR	= ../lib/debug
 
 #BASE		= /Developer/SDKs/MacOSX10.5.sdk/System/Library/Frameworks
-CXX      	= g++
+CC      	= clang
+CXX      	= clang++
 CXXFLAGS 	= $(CXXCFG) -Wall -fPIC -fno-strict-aliasing -D_MACOSX -ObjC++  -D__PLACEMENT_NEW_INLINE
 INCPATH  	= -I../include -I/usr/local/include -I/usr/X11R6/include -I/usr/include
 #-I$(BASE)/OpenGL.framework/Headers/ -I$(BASE)/GLUT.framework/Headers/ -I$(BASE)/AppKit.framework/Headers/
-LINK     	= g++
+LINK     	= clang++
 LIBS 		= -framework OpenGL -framework GLUT -framework AppKit
-AR       	= ar cqs
+AR       	= libtool -static -o
 RANLIB   	=
 TAR      	= tar -cf
 GZIP     	= gzip -9f
@@ -63,7 +64,6 @@ all: 	Makefile $(TARGET)
 
 $(TARGET): $(OBJS)
 	@echo "===== Link $@ ====="
-	$(LINK) $(LFLAGS) -dynamiclib -Wl,-undefined -Wl,dynamic_lookup  -o $(OUT_DIR)/lib$(TARGET)$(SO_EXT) $(OBJS) $(LIBS)
 	$(AR) $(OUT_DIR)/lib$(TARGET)$(AR_EXT) $(OBJS)
 
 .cpp.o:
@@ -72,7 +72,7 @@ $(TARGET): $(OBJS)
 
 .c.o:
 	@echo "===== Compile $< ====="
-	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o $@ $<
+	$(CC) -c $(CXXFLAGS) $(INCPATH) -o $@ $<
 
 clean:
 	@echo "===== Clean ====="

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -15,7 +15,7 @@ OUT_DIR		= ../lib
 #BASE		= /Developer/SDKs/MacOSX10.5.sdk/System/Library/Frameworks
 CC      	= clang
 CXX      	= clang++
-CXXFLAGS 	= $(CXXCFG) -Wall -fPIC -fno-strict-aliasing -D_MACOSX -ObjC++  -D__PLACEMENT_NEW_INLINE
+CXXFLAGS 	= $(CXXCFG) -Wall -fPIC -fno-strict-aliasing -D_MACOSX -ObjC++ -fobjc-arc -D__PLACEMENT_NEW_INLINE
 INCPATH  	= -I../include -I/usr/local/include -I/usr/X11R6/include -I/usr/include
 #-I$(BASE)/OpenGL.framework/Headers/ -I$(BASE)/GLUT.framework/Headers/ -I$(BASE)/AppKit.framework/Headers/
 LINK     	= clang++

--- a/src/TwMgr.cpp
+++ b/src/TwMgr.cpp
@@ -6375,8 +6375,6 @@ CTwMgr::CCursor CTwMgr::PixmapCursor(int _CurIdx)
     [img addRepresentation: imgr];
     NSCursor *cur = [[NSCursor alloc] initWithImage: img hotSpot: NSMakePoint(g_CurHot[_CurIdx][0],g_CurHot[_CurIdx][1])];
 
-    [imgr autorelease];
-    [img autorelease];
     if (cur)
         return cur;
     else
@@ -6388,49 +6386,31 @@ void CTwMgr::CreateCursors()
     if (m_CursorsCreated)
         return;
     
-    m_CursorArrow        = [[NSCursor arrowCursor] retain];
-    m_CursorMove         = [[NSCursor crosshairCursor] retain];
-    m_CursorWE           = [[NSCursor resizeLeftRightCursor] retain];
-    m_CursorNS           = [[NSCursor resizeUpDownCursor] retain];
-    m_CursorTopRight     = [[NSCursor arrowCursor] retain]; //osx not have one
-    m_CursorTopLeft      = [[NSCursor arrowCursor] retain]; //osx not have one
-    m_CursorBottomRight  = [[NSCursor arrowCursor] retain]; //osx not have one
-    m_CursorBottomLeft   = [[NSCursor arrowCursor] retain]; //osx not have one
-    m_CursorHelp         = [[NSCursor arrowCursor] retain]; //osx not have one
-    m_CursorHand         = [[NSCursor pointingHandCursor] retain];
-    m_CursorCross        = [[NSCursor arrowCursor] retain];
-    m_CursorUpArrow      = [[NSCursor arrowCursor] retain];
-    m_CursorNo           = [[NSCursor arrowCursor] retain];
-    m_CursorIBeam        = [[NSCursor IBeamCursor] retain];
+    m_CursorArrow        = [NSCursor arrowCursor];
+    m_CursorMove         = [NSCursor crosshairCursor];
+    m_CursorWE           = [NSCursor resizeLeftRightCursor];
+    m_CursorNS           = [NSCursor resizeUpDownCursor];
+    m_CursorTopRight     = [NSCursor arrowCursor]; //osx not have one
+    m_CursorTopLeft      = [NSCursor arrowCursor]; //osx not have one
+    m_CursorBottomRight  = [NSCursor arrowCursor]; //osx not have one
+    m_CursorBottomLeft   = [NSCursor arrowCursor]; //osx not have one
+    m_CursorHelp         = [NSCursor arrowCursor]; //osx not have one
+    m_CursorHand         = [NSCursor pointingHandCursor];
+    m_CursorCross        = [NSCursor arrowCursor];
+    m_CursorUpArrow      = [NSCursor arrowCursor];
+    m_CursorNo           = [NSCursor arrowCursor];
+    m_CursorIBeam        = [NSCursor IBeamCursor];
     for (int i=0;i<NB_ROTO_CURSORS; i++)
     {
-        m_RotoCursors[i] = [PixmapCursor(i+2) retain];
+        m_RotoCursors[i] = PixmapCursor(i+2);
     }
-    m_CursorCenter  = [PixmapCursor(0) retain];
-    m_CursorPoint   = [PixmapCursor(1) retain];
+    m_CursorCenter  = PixmapCursor(0);
+    m_CursorPoint   = PixmapCursor(1);
     m_CursorsCreated = true;
 }
 
 void CTwMgr::FreeCursors()
 {
-    [m_CursorArrow release];
-    [m_CursorMove release];
-    [m_CursorWE release];
-    [m_CursorNS release];
-    [m_CursorTopRight release];
-    [m_CursorTopLeft release];
-    [m_CursorBottomRight release];
-    [m_CursorBottomLeft release];
-    [m_CursorHelp release];
-    [m_CursorHand release];
-    [m_CursorCross release];
-    [m_CursorUpArrow release];
-    [m_CursorNo release];
-    [m_CursorIBeam release];
-    for( int i=0; i<NB_ROTO_CURSORS; ++i )
-        [m_RotoCursors[i] release]; 
-    [m_CursorCenter release];
-    [m_CursorPoint release];
     m_CursorsCreated = false;
 }
 

--- a/src/TwMgr.cpp
+++ b/src/TwMgr.cpp
@@ -5112,7 +5112,7 @@ bool TwGetKeyCode(int *_Code, int *_Modif, const char *_String)
     bool Ok = true;
     *_Modif = TW_KMOD_NONE;
     *_Code = 0;
-    size_t Start = strlen(_String)-1;
+    int Start = (int)strlen(_String)-1;
     if( Start<0 )
         return false;
     while( Start>0 && _String[Start-1]!='+' )
@@ -5120,7 +5120,7 @@ bool TwGetKeyCode(int *_Code, int *_Modif, const char *_String)
     while( _String[Start]==' ' || _String[Start]=='\t' )
         ++Start;
     char *CodeStr = _strdup(_String+Start);
-    for( size_t i=strlen(CodeStr)-1; i>=0; ++i )
+    for( int i=(int)strlen(CodeStr)-1; i>=0; --i )
         if( CodeStr[i]==' ' || CodeStr[i]=='\t' )
             CodeStr[i] = '\0';
         else
@@ -6369,7 +6369,7 @@ CTwMgr::CCursor CTwMgr::PixmapCursor(int _CurIdx)
     for (y=0;y<32;y++) {
         for (x=0;x<32;x++) {
             //printf("%d",g_CurMask[_CurIdx][x+y*32]);
-            data[(x>>2) + y*8] |= (unsigned char)(g_CurPict[_CurIdx][x+y*32] << 2*(3-(x&3))+1); //turn whiteon
+            data[(x>>2) + y*8] |= (unsigned char)(g_CurPict[_CurIdx][x+y*32] << (2*(3-(x&3))+1)); //turn whiteon
             data[(x>>2) + y*8] |= (unsigned char)(g_CurMask[_CurIdx][x+y*32] << 2*(3-(x&3))); //turn the alpha all the way up
         }
         //printf("\n");


### PR DESCRIPTION
This PR fixes a crash that can occur if `TwTerminate` is called during process shutdown, and the global variable `g_Wnds`, which is a `std::map`, has already been destroyed.

In addition to fixing the crashing issue on shutdown, this PR includes fixing a few small bugs, and also adding support for building on a modern version of macOS.